### PR TITLE
Add option to ignore files and exclude include types

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ gulp.src('public/index.html')
     base: 'public/',
     js: uglify(),
     css: minifyCss(),
+    disabledTypes: ['svg', 'img', 'js'], // Only inline css files
     ignore: ['./css/do-not-inline-me.css']
   }))
   .pipe(gulp.dest('dist/'));
@@ -39,5 +40,5 @@ Plugin options:
   * css - css transform (gulp plugin)
   * js - js transform (gulp plugin)
   * svg - svg transform (gulp plugin)
-  * ignore - an array of file paths to ignore and not inline (file paths as they appear in the source)
-
+  * ignore - array of file paths to ignore and not inline (file paths as they appear in the source)
+  * disabledTypes - array of types not to run inlining operations on (css, svg, js, img)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ gulp.src('public/index.html')
   .pipe(inline({
     base: 'public/',
     js: uglify(),
-    css: minifyCss()
+    css: minifyCss(),
+    ignore: ['./css/do-not-inline-me.css']
   }))
   .pipe(gulp.dest('dist/'));
 ```
@@ -38,4 +39,5 @@ Plugin options:
   * css - css transform (gulp plugin)
   * js - js transform (gulp plugin)
   * svg - svg transform (gulp plugin)
+  * ignore - an array of file paths to ignore and not inline (file paths as they appear in the source)
 

--- a/test/fixtures/basic.html
+++ b/test/fixtures/basic.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <script type='text/javascript' src='/basic.js'></script>
-    <link rel='stylesheet' href='/basic.css'></script>
+    <link rel='stylesheet' href='/basic.css'>
   </head>
   <body>
     <img src='/basic.svg'>

--- a/test/fixtures/disable-output.html
+++ b/test/fixtures/disable-output.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <script type="text/javascript" src="/foo.js"></script>
+    <link rel="stylesheet" href="/foo.css">
+  </head>
+  <body>
+    <img src="/foo.svg">
+  </body>
+</html>

--- a/test/fixtures/disable.html
+++ b/test/fixtures/disable.html
@@ -1,0 +1,9 @@
+<html>
+  <head>
+    <script type='text/javascript' src='/foo.js'></script>
+    <link rel='stylesheet' href='/foo.css'>
+  </head>
+  <body>
+    <img src='/foo.svg'>
+  </body>
+</html>

--- a/test/fixtures/ignore-output.html
+++ b/test/fixtures/ignore-output.html
@@ -1,0 +1,18 @@
+<html>
+  <head>
+    <script type="text/javascript">
+var basic = 'test';
+</script>
+    <script type="text/javascript" src="/ignore.js"></script>
+    <style>
+.basic {
+  color: blue;
+}
+</style>
+    <link rel="stylesheet" href="/ignore.css">
+  </head>
+  <body>
+    <svg xmlns="http://www.w3.org/2000/svg"></svg>
+    <img src="/ignore.svg">
+  </body>
+</html>

--- a/test/fixtures/ignore.css
+++ b/test/fixtures/ignore.css
@@ -1,0 +1,3 @@
+.ignore {
+  color: red;
+}

--- a/test/fixtures/ignore.html
+++ b/test/fixtures/ignore.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <script type='text/javascript' src='/basic.js'></script>
+    <script type='text/javascript' src='/ignore.js'></script>
+    <link rel='stylesheet' href='/basic.css'></link>
+    <link rel='stylesheet' href='/ignore.css'></link>
+  </head>
+  <body>
+    <img src='/basic.svg'>
+    <img src='/ignore.svg'>
+  </body>
+</html>

--- a/test/fixtures/ignore.js
+++ b/test/fixtures/ignore.js
@@ -1,0 +1,1 @@
+var ignore = 'test';

--- a/test/fixtures/ignore.svg
+++ b/test/fixtures/ignore.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"></svg>

--- a/test/main.js
+++ b/test/main.js
@@ -69,4 +69,16 @@ describe('gulp-inline', function() {
         done();
       });
   });
+
+  it('should ignore tag types if option is set', function(done) {
+    gulp.src(path.join(base, 'disable.html'))
+      .pipe(inline({
+        disabledTypes: ['svg', 'img', 'js', 'css'],
+        base: base
+      }))
+      .on('data', function(file) {
+        expect(String(file.contents)).to.equal(fs.readFileSync(path.join(base, 'disable-output.html'), 'utf8'));
+        done();
+      });
+  });
 });

--- a/test/main.js
+++ b/test/main.js
@@ -57,4 +57,16 @@ describe('gulp-inline', function() {
         done();
       });
   });
+
+  it('should ignore files if option is set', function(done) {
+    gulp.src(path.join(base, 'ignore.html'))
+      .pipe(inline({
+        ignore: ['/ignore.js', '/ignore.css', '/ignore.svg'],
+        base: base
+      }))
+      .on('data', function(file) {
+        expect(String(file.contents)).to.equal(fs.readFileSync(path.join(base, 'ignore-output.html'), 'utf8'));
+        done();
+      });
+  });
 });


### PR DESCRIPTION
We're looking at inline some but not all files in a project at work. This PR makes that possible by adding: 

- `disabledTypes` option which allows a user to only inline certain types of files (eg. only CSS)
- `ignore` option which allows a user to ignore certain files (eg. only inline 1 css file not all)

Let me know if there is anything that needs changing style/naming wise. I did think about adding glob support to the ignore option so you can do things like `ignore: ['/css/foo.css, /vendor/*.css']` - but figured this solution was good enough and didnt add any extra deps.