### PR TITLE
Use latest cheerio version 0.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compress html"
   ],
   "dependencies": {
-    "cheerio": "^0.18.0",
+    "cheerio": "^0.19.0",
     "event-stream": "~3.1.0",
     "gulp-util": "^3.0.1",
     "through2": "~0.4.1"


### PR DESCRIPTION
Cheerio 0.18.0 has a bug that breaks SVGs containing self-closing tags

https://github.com/cheeriojs/cheerio/issues/521