### PR TITLE
Fix transform stream usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ var inline = require('gulp-inline')
 gulp.src('public/index.html')
   .pipe(inline({
     base: 'public/',
-    js: uglify(),
-    css: minifyCss(),
+    js: uglify,
+    css: minifyCss,
     disabledTypes: ['svg', 'img', 'js'], // Only inline css files
     ignore: ['./css/do-not-inline-me.css']
   }))

--- a/index.js
+++ b/index.js
@@ -78,6 +78,10 @@ var typeMap = {
 function inject ($, process, base, cb, opts, relative, ignoredFiles) {
   var items = []
 
+  if (!process) {
+    process = noop;
+  }
+
   $(opts.tag).each(function (idx, el) {
     el = $(el)
     if (opts.filter(el)) {
@@ -93,7 +97,7 @@ function inject ($, process, base, cb, opts, relative, ignoredFiles) {
 
       if (fs.existsSync(file) && ignoredFiles.indexOf(src) === -1) {
         gulp.src(file)
-          .pipe(process || noop())
+          .pipe(process())
           .pipe(replace(el, opts.template))
           .pipe(through.obj(function (file, enc, cb) {
             cb()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-inline",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "description": "Inline styles and scripts into an html file.",
   "main": "index.js",
   "scripts": {
@@ -23,7 +23,8 @@
     "coverage-percentage": "*",
     "coverage-badge": "git://github.com/ashaffer/node-coverage-badge#patch-1",
     "istanbul": "~0.2.6",
-    "gulp": "^3.8.7"
+    "gulp": "^3.8.7",
+    "readable-stream": "^2.0.0"
   },
   "standard": {
     "globals": [

--- a/test/fixtures/basic-transform-output.html
+++ b/test/fixtures/basic-transform-output.html
@@ -1,0 +1,3 @@
+<style>
+Transformed file
+</style>

--- a/test/fixtures/basic-transform.html
+++ b/test/fixtures/basic-transform.html
@@ -1,0 +1,1 @@
+<link rel='stylesheet' href='/basic.css'>

--- a/test/main.js
+++ b/test/main.js
@@ -7,6 +7,7 @@ var gulp = require('gulp')
 var fs = require('fs')
 var path = require('path')
 var inline = require('..')
+var transform = require('readable-stream/transform')
 var base = 'test/fixtures'
 
 /**
@@ -82,6 +83,29 @@ describe('gulp-inline', function () {
         done()
       })
   })
+
+  it('should run Transform stream on files', function(done) {
+    gulp.src(path.join(base, 'basic-transform.html'))
+      .pipe(inline({
+        css: dummyTransform,
+        base: base
+      }))
+      .on('data', function (file) {
+        assert.equal(String(file.contents), fs.readFileSync(path.join(base, 'basic-transform-output.html'), 'utf8'))
+        done()
+      })
+  });
+
+  function dummyTransform() {
+    return new transform({
+      objectMode: true,
+      transform: function(file, enc, cb) {
+        file.contents = new Buffer("Transformed file");
+        this.push(file);
+        cb();
+      }
+    });
+  }
 
   function inputOutput (name, done) {
     gulp.src(path.join(base, name + '.html'))


### PR DESCRIPTION
I couldn't get transform streams (gulp-minify-css, gulp-svgmin) working as described in the README.
I fixed it by calling transform inside gulp-inline instead of calling it in gulp task.
Additionally I added a test case using basic `Transform` stream set on CSS file.