### PR TITLE
Inline SVG via <use> element

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,54 @@ gulp.src('public/index.html')
 
 Replaces your &lt;script&gt; and &lt;link&gt; tags with the corresponding inlined files.
 
+## SVG support
+
+Currently there are two supported methods:
+
+- `<img>` element with `src` attribute:
+
+  ```
+  <img src="/assets/icon.svg" class="MyClass" />
+  ```
+
+  which will be converted to something like
+
+  ```
+  <svg xmlns="http://www.w3.org/2000/svg" viewbox="..." class="MyClass">
+    <circle ... />
+    <path ... />
+    etc.
+  </svg>
+  ```
+
+  depending on what `/assets/icon.svg` contains
+
+- `<svg>` element with `<use>` child element:
+
+  ```
+  <svg>
+    <use xlink:href="/assets/icon.svg#MyIdentifier"></use>
+  </svg>
+  ```
+
+  Note that this method requires an ID matching the ID of target SVG root element.
+
+  This is valid target SVG for the example above:
+
+  ```
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="MyIdentifier">
+    ...
+  </svg>
+  ```
+
+  while this is invalid:
+
+  ```
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+    ...
+  </svg>
+  ```
+
 ## Options
 
 Plugin options:

--- a/index.js
+++ b/index.js
@@ -60,17 +60,55 @@ var typeMap = {
   },
 
   svg: {
-    tag: 'img',
+    tag: ['img', 'svg'],
     template: function (contents, el) {
-      var $ = cheerio.load(String(contents), {decodeEntities: false})
-      return cheerio.html($('svg').attr(without(el.attr(), 'src')))
+      var tag = el[0].tagName,
+          $ = cheerio.load(String(contents), {decodeEntities: false})
+
+      switch (tag) {
+        case 'img':
+          return cheerio.html($('svg').attr(without(el.attr(), 'src')))
+          break;
+        case 'svg':
+          return cheerio.html($('svg').removeAttr('id').attr(without(el.attr(), 'src')))
+          break;
+      }
     },
     filter: function (el) {
-      var src = el.attr('src')
-      return /\.svg$/.test(src) && isLocal(src)
+      var tag = el[0].tagName;
+
+      switch (tag) {
+        case 'img':
+          var src = el.attr('src')
+          return /\.svg$/.test(src) && isLocal(src)
+          break;
+        case 'svg':
+          var children = el.children(),
+              child    = children.first(),
+              src      = child.attr('xlink:href');
+
+          // Return TRUE if element contains only one child element and
+          // that child element is a <use> element with xlink:href
+          // attribute which refers to some random ID (which according to
+          // HTML5 spec should contain at least one character and shouldn't
+          // contain spaces) in external SVG file
+          return children.length === 1
+            && child[0].tagName === 'use'
+            && /\.svg#\S+$/.test(src);
+          break;
+      }
     },
     getSrc: function (el) {
-      return el.attr('src')
+      var tag = el[0].tagName;
+
+      switch (tag) {
+        case 'img':
+          return el.attr('src')
+        case 'svg':
+          // Return "/foo.svg" out of "/foo.svg#SomeIdentifier"
+          return el.children().first().attr('xlink:href').match(/[^#]+/)[0];
+          break;
+      }
     }
   }
 }
@@ -78,11 +116,16 @@ var typeMap = {
 function inject ($, process, base, cb, opts, relative, ignoredFiles) {
   var items = []
 
-  $(opts.tag).each(function (idx, el) {
-    el = $(el)
-    if (opts.filter(el)) {
-      items.push(el)
-    }
+  // Normalize tags
+  var tags = opts.tag instanceof Array ? opts.tag : [opts.tag];
+
+  tags.forEach(function(tag) {
+    $(tag).each(function (idx, el) {
+      el = $(el)
+      if (opts.filter(el)) {
+        items.push(el)
+      }
+    })
   })
 
   if (items.length) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-inline",
-  "version": "0.0.15",
+  "version": "0.1.0",
   "description": "Inline styles and scripts into an html file.",
   "main": "index.js",
   "scripts": {

--- a/test/fixtures/attrs-output.html
+++ b/test/fixtures/attrs-output.html
@@ -10,6 +10,9 @@ var basic = 'test';
 </style>
   </head>
   <body>
-    <svg xmlns="http://www.w3.org/2000/svg" width="400"/>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 32 32" id="BasicSVGIcon" width="400">
+  <circle fill="#000000" cx="1" cy="1" r="10" class="BasicSVGIcon-circle"/>
+  <path fill="#000000" d="M10..." class="BasicSVGIcon-path"/>
+</svg>
   </body>
 </html>

--- a/test/fixtures/basic-output.html
+++ b/test/fixtures/basic-output.html
@@ -10,6 +10,9 @@ var basic = 'test';
 </style>
   </head>
   <body>
-    <svg xmlns="http://www.w3.org/2000/svg"/>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 32 32" id="BasicSVGIcon">
+  <circle fill="#000000" cx="1" cy="1" r="10" class="BasicSVGIcon-circle"/>
+  <path fill="#000000" d="M10..." class="BasicSVGIcon-path"/>
+</svg>
   </body>
 </html>

--- a/test/fixtures/basic.svg
+++ b/test/fixtures/basic.svg
@@ -1,1 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg"></svg>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" id="BasicSVGIcon">
+  <circle fill="#000000" cx="1" cy="1" r="10" class="BasicSVGIcon-circle"/>
+  <path fill="#000000" d="M10..." class="BasicSVGIcon-path"/>
+</svg>

--- a/test/fixtures/ignore-output.html
+++ b/test/fixtures/ignore-output.html
@@ -12,7 +12,10 @@ var basic = 'test';
     <link rel="stylesheet" href="/ignore.css">
   </head>
   <body>
-    <svg xmlns="http://www.w3.org/2000/svg"/>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 32 32" id="BasicSVGIcon">
+  <circle fill="#000000" cx="1" cy="1" r="10" class="BasicSVGIcon-circle"/>
+  <path fill="#000000" d="M10..." class="BasicSVGIcon-path"/>
+</svg>
     <img src="/ignore.svg">
   </body>
 </html>

--- a/test/fixtures/svg-output.html
+++ b/test/fixtures/svg-output.html
@@ -1,5 +1,8 @@
 <html>
   <body>
-    <svg xmlns="http://www.w3.org/2000/svg"/>
+    <svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 32 32" id="BasicSVGIcon">
+  <circle fill="#000000" cx="1" cy="1" r="10" class="BasicSVGIcon-circle"/>
+  <path fill="#000000" d="M10..." class="BasicSVGIcon-path"/>
+</svg>
   </body>
 </html>

--- a/test/fixtures/svg-use-output.html
+++ b/test/fixtures/svg-use-output.html
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 32 32" class="MyBasicSVGIcon">
+  <circle fill="#000000" cx="1" cy="1" r="10" class="BasicSVGIcon-circle"/>
+  <path fill="#000000" d="M10..." class="BasicSVGIcon-path"/>
+</svg>

--- a/test/fixtures/svg-use.html
+++ b/test/fixtures/svg-use.html
@@ -1,0 +1,3 @@
+<svg class="MyBasicSVGIcon">
+  <use xlink:href="/basic.svg#BasicSVGIcon"></use>
+</svg>

--- a/test/main.js
+++ b/test/main.js
@@ -83,6 +83,10 @@ describe('gulp-inline', function () {
       })
   })
 
+  it('should inline SVG referenced in <use> tag', function (done) {
+    inputOutput('svg-use', done)
+  })
+
   function inputOutput (name, done) {
     gulp.src(path.join(base, name + '.html'))
       .pipe(inline({base: base}))


### PR DESCRIPTION
Introducting support for transforming something like this:

```
<svg>
  <use xlink:href="/assets/icon.svg#MyIdentifier"></use>
</svg>
```

into something like this:

```
<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
  ...
</svg>
```

`basic.svg` was rewritten a little bit for more realistic tests but no backward-functionality was broken.