### PR TITLE
Security Fix: Remove unused gulp-util dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "cheerio": "^0.22.0",
     "event-stream": "^3.3.4",
-    "gulp-util": "^3.0.7",
     "through2": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-inline",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Inline styles and scripts into an html file.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Gulp-util is no longer used by gulp-inline and has been deprecated. Removing here to remove security vulnerability caused by transitive dependency lodash.template@3.6.2.